### PR TITLE
Add a "Moving Platform" PhysX collision group

### DIFF
--- a/Projects/FirstPersonProject/Assets/Scripts/VertMovement.scriptcanvas
+++ b/Projects/FirstPersonProject/Assets/Scripts/VertMovement.scriptcanvas
@@ -5,7 +5,7 @@
     "ClassData": {
         "m_scriptCanvas": {
             "Id": {
-                "id": 5844516464641
+                "id": 162893441955986
             },
             "Name": "Script Canvas Graph",
             "Components": {
@@ -16,7 +16,7 @@
                         "m_nodes": [
                             {
                                 "Id": {
-                                    "id": 5874581235713
+                                    "id": 163022290974866
                                 },
                                 "Name": "SC-Node(Gate)",
                                 "Components": {
@@ -107,7 +107,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 5908940974081
+                                    "id": 162953571498130
                                 },
                                 "Name": "SC-Node(OperatorMul)",
                                 "Components": {
@@ -371,7 +371,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 144889787705345
+                                    "id": 162996521171090
                                 },
                                 "Name": "SC-Node(GetParentId)",
                                 "Components": {
@@ -476,7 +476,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 144894082672641
+                                    "id": 163069535615122
                                 },
                                 "Name": "SC-Node(GetParentId)",
                                 "Components": {
@@ -581,7 +581,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 144885492738049
+                                    "id": 163039470844050
                                 },
                                 "Name": "SC-Node(NotEqualTo)",
                                 "Components": {
@@ -734,7 +734,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 144902672607233
+                                    "id": 162944981563538
                                 },
                                 "Name": "SC-Node(Gate)",
                                 "Components": {
@@ -825,7 +825,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 144876902803457
+                                    "id": 162970751367314
                                 },
                                 "Name": "SC-Node(NotEqualTo)",
                                 "Components": {
@@ -978,7 +978,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 144915557509121
+                                    "id": 163009406072978
                                 },
                                 "Name": "SC-Node(NotEqualTo)",
                                 "Components": {
@@ -1135,7 +1135,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 5951890647041
+                                    "id": 163056650713234
                                 },
                                 "Name": "SC-Node(GetWorldBounds)",
                                 "Components": {
@@ -1240,7 +1240,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 5947595679745
+                                    "id": 162979341301906
                                 },
                                 "Name": "EBusEventHandler",
                                 "Components": {
@@ -1479,7 +1479,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 5956185614337
+                                    "id": 163091010451602
                                 },
                                 "Name": "SC-Node(ScriptCanvas_Vector3Functions_GetElement)",
                                 "Components": {
@@ -1614,7 +1614,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 144906967574529
+                                    "id": 163103895353490
                                 },
                                 "Name": "SC-Node(GetCollisionGroupName)",
                                 "Components": {
@@ -1719,7 +1719,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 5926120843265
+                                    "id": 162936391628946
                                 },
                                 "Name": "SC-Node(ScriptCanvas_Vector3Functions_FromValues)",
                                 "Components": {
@@ -1879,7 +1879,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 144898377639937
+                                    "id": 163030880909458
                                 },
                                 "Name": "SC-Node(NotEqualTo)",
                                 "Components": {
@@ -2036,7 +2036,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 5930415810561
+                                    "id": 163082420517010
                                 },
                                 "Name": "SC-Node(GetWorldZ)",
                                 "Components": {
@@ -2141,7 +2141,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 5934710777857
+                                    "id": 163099600386194
                                 },
                                 "Name": "SC-Node(InputHandlerNodeableNode)",
                                 "Components": {
@@ -2372,7 +2372,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6046379927553
+                                    "id": 163060945680530
                                 },
                                 "Name": "SC-Node(Gate)",
                                 "Components": {
@@ -2463,7 +2463,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6042084960257
+                                    "id": 162983636269202
                                 },
                                 "Name": "SC-Node(Less)",
                                 "Components": {
@@ -2612,7 +2612,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 144872607836161
+                                    "id": 163000816138386
                                 },
                                 "Name": "SC-Node(SetParent)",
                                 "Components": {
@@ -2733,7 +2733,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 144881197770753
+                                    "id": 163108190320786
                                 },
                                 "Name": "SC-Node(SetParent)",
                                 "Components": {
@@ -2850,7 +2850,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6037789992961
+                                    "id": 162975046334610
                                 },
                                 "Name": "SC-Node(Less)",
                                 "Components": {
@@ -2999,7 +2999,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6007725221889
+                                    "id": 162966456400018
                                 },
                                 "Name": "SC Node(SetVariable)",
                                 "Components": {
@@ -3101,7 +3101,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6016315156481
+                                    "id": 163026585942162
                                 },
                                 "Name": "SC Node(SetVariable)",
                                 "Components": {
@@ -3203,7 +3203,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 144911262541825
+                                    "id": 163017996007570
                                 },
                                 "Name": "SC-Node(ScriptCanvasPhysics_WorldFunctions_RayCastLocalSpaceWithGroup)",
                                 "Components": {
@@ -3528,7 +3528,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 5986250385409
+                                    "id": 163005111105682
                                 },
                                 "Name": "SC-Node(ScriptCanvasPhysics_WorldFunctions_RayCastLocalSpaceWithGroup)",
                                 "Components": {
@@ -3849,7 +3849,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 5994840320001
+                                    "id": 163073830582418
                                 },
                                 "Name": "SC-Node(ScriptCanvasPhysics_WorldFunctions_RayCastLocalSpaceWithGroup)",
                                 "Components": {
@@ -4170,7 +4170,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 5990545352705
+                                    "id": 163065240647826
                                 },
                                 "Name": "SC-Node(ScriptCanvas_Vector3Functions_GetElement)",
                                 "Components": {
@@ -4305,7 +4305,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 144919852476417
+                                    "id": 163052355745938
                                 },
                                 "Name": "SC Node(SetVariable)",
                                 "Components": {
@@ -4409,7 +4409,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 5921825875969
+                                    "id": 162932096661650
                                 },
                                 "Name": "SC-Node(Gate)",
                                 "Components": {
@@ -4500,7 +4500,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 5981955418113
+                                    "id": 163043765811346
                                 },
                                 "Name": "SC-Node(Gate)",
                                 "Components": {
@@ -4591,7 +4591,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 5917530908673
+                                    "id": 163095305418898
                                 },
                                 "Name": "SC-Node(Get Gravity)",
                                 "Components": {
@@ -4696,7 +4696,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 5861696333825
+                                    "id": 162927801694354
                                 },
                                 "Name": "SC-Node(OperatorSub)",
                                 "Components": {
@@ -4939,7 +4939,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 5865991301121
+                                    "id": 163086715484306
                                 },
                                 "Name": "SC-Node(Gate)",
                                 "Components": {
@@ -5034,7 +5034,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 5870286268417
+                                    "id": 162940686596242
                                 },
                                 "Name": "SC-Node(GetVelocity)",
                                 "Components": {
@@ -5139,7 +5139,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 5913235941377
+                                    "id": 162923506727058
                                 },
                                 "Name": "SC-Node(Get Camera Pitch)",
                                 "Components": {
@@ -5244,7 +5244,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 5896056072193
+                                    "id": 162949276530834
                                 },
                                 "Name": "SC-Node(Set Left Input Value)",
                                 "Components": {
@@ -5359,7 +5359,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 5900351039489
+                                    "id": 162910621825170
                                 },
                                 "Name": "SC-Node(Set Right Input Value)",
                                 "Components": {
@@ -5474,7 +5474,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 5939005745153
+                                    "id": 162957866465426
                                 },
                                 "Name": "SC-Node(Sin)",
                                 "Components": {
@@ -5577,7 +5577,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 5943300712449
+                                    "id": 162987931236498
                                 },
                                 "Name": "SC Node(SetVariable)",
                                 "Components": {
@@ -5679,7 +5679,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6020610123777
+                                    "id": 162897736923282
                                 },
                                 "Name": "SC-Node(Set Forward Input Value)",
                                 "Components": {
@@ -5794,7 +5794,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6024905091073
+                                    "id": 162902031890578
                                 },
                                 "Name": "SC-Node(Set Apply Velocity Z)",
                                 "Components": {
@@ -5909,7 +5909,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 5999135287297
+                                    "id": 162962161432722
                                 },
                                 "Name": "SC-Node(ScriptCanvas_AABBFunctions_GetMax)",
                                 "Components": {
@@ -6022,7 +6022,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6003430254593
+                                    "id": 162992226203794
                                 },
                                 "Name": "SC-Node(HasTag)",
                                 "Components": {
@@ -6158,7 +6158,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 5960480581633
+                                    "id": 162906326857874
                                 },
                                 "Name": "SC-Node(HasTag)",
                                 "Components": {
@@ -6294,7 +6294,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 5964775548929
+                                    "id": 163048060778642
                                 },
                                 "Name": "SC-Node(Start)",
                                 "Components": {
@@ -6324,7 +6324,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 5969070516225
+                                    "id": 162914916792466
                                 },
                                 "Name": "SC-Node(OperatorMul)",
                                 "Components": {
@@ -6588,7 +6588,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 5973365483521
+                                    "id": 162919211759762
                                 },
                                 "Name": "SC Node(SetVariable)",
                                 "Components": {
@@ -6690,7 +6690,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 5857401366529
+                                    "id": 163035175876754
                                 },
                                 "Name": "SC-Node(AddVelocity)",
                                 "Components": {
@@ -6809,7 +6809,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 5848811431937
+                                    "id": 163078125549714
                                 },
                                 "Name": "SC-Node(Set Gravity)",
                                 "Components": {
@@ -6928,7 +6928,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 5853106399233
+                                    "id": 163013701040274
                                 },
                                 "Name": "SC-Node(Set Gravity)",
                                 "Components": {
@@ -7045,7 +7045,7 @@
                         "m_connections": [
                             {
                                 "Id": {
-                                    "id": 6050674894849
+                                    "id": 163112485288082
                                 },
                                 "Name": "srcEndpoint=(TickBus Handler: ExecutionSlot:OnTick), destEndpoint=(ScriptCanvasPhysics_WorldFunctions_RayCastLocalSpaceWithGroup: In)",
                                 "Components": {
@@ -7054,7 +7054,7 @@
                                         "Id": 10220948229145284335,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5947595679745
+                                                "id": 162979341301906
                                             },
                                             "slotId": {
                                                 "m_id": "{1D526426-987A-457D-B6E0-297A23A2616A}"
@@ -7062,7 +7062,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5994840320001
+                                                "id": 163073830582418
                                             },
                                             "slotId": {
                                                 "m_id": "{1187B21C-F2D4-4F34-9008-920C7A1C2225}"
@@ -7073,7 +7073,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6054969862145
+                                    "id": 163116780255378
                                 },
                                 "Name": "srcEndpoint=(Sin: Out), destEndpoint=(Multiply (*): In)",
                                 "Components": {
@@ -7082,7 +7082,7 @@
                                         "Id": 11627840068257611364,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5939005745153
+                                                "id": 162957866465426
                                             },
                                             "slotId": {
                                                 "m_id": "{B34C4404-BF69-4C6B-B709-DB9743899E1D}"
@@ -7090,7 +7090,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5969070516225
+                                                "id": 162914916792466
                                             },
                                             "slotId": {
                                                 "m_id": "{14F51482-5ABC-4ABC-9344-A7C560562061}"
@@ -7101,7 +7101,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6059264829441
+                                    "id": 163121075222674
                                 },
                                 "Name": "srcEndpoint=(Sin: Number), destEndpoint=(Multiply (*): Value 0)",
                                 "Components": {
@@ -7110,7 +7110,7 @@
                                         "Id": 10900155119114276445,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5939005745153
+                                                "id": 162957866465426
                                             },
                                             "slotId": {
                                                 "m_id": "{A10377A4-0DEF-4B9D-B563-918FE93DC1BE}"
@@ -7118,7 +7118,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5969070516225
+                                                "id": 162914916792466
                                             },
                                             "slotId": {
                                                 "m_id": "{5E93A355-26CB-4351-93AD-8084AC1C0615}"
@@ -7129,7 +7129,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6063559796737
+                                    "id": 163125370189970
                                 },
                                 "Name": "srcEndpoint=(Multiply (*): Out), destEndpoint=(Set Variable: In)",
                                 "Components": {
@@ -7138,7 +7138,7 @@
                                         "Id": 2399855350587766797,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5969070516225
+                                                "id": 162914916792466
                                             },
                                             "slotId": {
                                                 "m_id": "{A0645682-E937-4FBD-B3BB-554A3EB40D01}"
@@ -7146,7 +7146,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5973365483521
+                                                "id": 162919211759762
                                             },
                                             "slotId": {
                                                 "m_id": "{297289DA-A634-4980-92E5-5E31C0998BC6}"
@@ -7157,7 +7157,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6067854764033
+                                    "id": 163129665157266
                                 },
                                 "Name": "srcEndpoint=(Multiply (*): Result), destEndpoint=(Set Variable: Number)",
                                 "Components": {
@@ -7166,7 +7166,7 @@
                                         "Id": 12131805381045830263,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5969070516225
+                                                "id": 162914916792466
                                             },
                                             "slotId": {
                                                 "m_id": "{AC86A47B-079E-4B00-8D6B-A9A554582874}"
@@ -7174,7 +7174,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5973365483521
+                                                "id": 162919211759762
                                             },
                                             "slotId": {
                                                 "m_id": "{E26DBF7A-47B4-41A7-8FB5-6B2A848164A2}"
@@ -7185,7 +7185,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6072149731329
+                                    "id": 163133960124562
                                 },
                                 "Name": "srcEndpoint=(Get Camera Pitch: Number), destEndpoint=(Sin: Number)",
                                 "Components": {
@@ -7194,7 +7194,7 @@
                                         "Id": 6584552758857635602,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5913235941377
+                                                "id": 162923506727058
                                             },
                                             "slotId": {
                                                 "m_id": "{3327EF08-C3AB-48E1-AB22-DCE63A21BCA1}"
@@ -7202,7 +7202,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5939005745153
+                                                "id": 162957866465426
                                             },
                                             "slotId": {
                                                 "m_id": "{1BB8BE16-B103-4ECB-ABE9-E72ECA739AFB}"
@@ -7213,7 +7213,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6076444698625
+                                    "id": 163138255091858
                                 },
                                 "Name": "srcEndpoint=(Get Camera Pitch: Out), destEndpoint=(Sin: In)",
                                 "Components": {
@@ -7222,7 +7222,7 @@
                                         "Id": 7750412294814192275,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5913235941377
+                                                "id": 162923506727058
                                             },
                                             "slotId": {
                                                 "m_id": "{9A49D046-36A5-43A4-9F1E-5EAFC2912A02}"
@@ -7230,7 +7230,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5939005745153
+                                                "id": 162957866465426
                                             },
                                             "slotId": {
                                                 "m_id": "{F4EFCB70-4565-45EF-8325-27F8F83AAC83}"
@@ -7241,7 +7241,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6080739665921
+                                    "id": 163142550059154
                                 },
                                 "Name": "srcEndpoint=(HasTag: Boolean), destEndpoint=(If: Condition)",
                                 "Components": {
@@ -7250,7 +7250,7 @@
                                         "Id": 6084063400274947831,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 6003430254593
+                                                "id": 162992226203794
                                             },
                                             "slotId": {
                                                 "m_id": "{270932F5-D9F2-4FC5-B88E-ECE6A1D111B6}"
@@ -7258,7 +7258,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 6046379927553
+                                                "id": 163060945680530
                                             },
                                             "slotId": {
                                                 "m_id": "{1C24D83D-3DC2-4BFF-8C88-B883EBEBA275}"
@@ -7269,7 +7269,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6085034633217
+                                    "id": 163146845026450
                                 },
                                 "Name": "srcEndpoint=(HasTag: Out), destEndpoint=(If: In)",
                                 "Components": {
@@ -7278,7 +7278,7 @@
                                         "Id": 16152534294697561927,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 6003430254593
+                                                "id": 162992226203794
                                             },
                                             "slotId": {
                                                 "m_id": "{E54D49AE-81AE-4B02-B219-BE2951A0527F}"
@@ -7286,7 +7286,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 6046379927553
+                                                "id": 163060945680530
                                             },
                                             "slotId": {
                                                 "m_id": "{FB85688E-A8F2-40FA-8A09-BE7F713BB39D}"
@@ -7297,7 +7297,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6089329600513
+                                    "id": 163151139993746
                                 },
                                 "Name": "srcEndpoint=(If: True), destEndpoint=(Set Variable: In)",
                                 "Components": {
@@ -7306,7 +7306,7 @@
                                         "Id": 5089682511242517890,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 6046379927553
+                                                "id": 163060945680530
                                             },
                                             "slotId": {
                                                 "m_id": "{A371DE13-0124-4EED-82E9-63481B3EF79B}"
@@ -7314,7 +7314,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 6016315156481
+                                                "id": 163026585942162
                                             },
                                             "slotId": {
                                                 "m_id": "{BB73C160-3A27-4DC4-A45D-A285C1093467}"
@@ -7325,7 +7325,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6093624567809
+                                    "id": 163155434961042
                                 },
                                 "Name": "srcEndpoint=(If: False), destEndpoint=(Set Variable: In)",
                                 "Components": {
@@ -7334,7 +7334,7 @@
                                         "Id": 13180234553530509889,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 6046379927553
+                                                "id": 163060945680530
                                             },
                                             "slotId": {
                                                 "m_id": "{DFA8CBE0-0ED4-45BF-9924-75EDC7E0DEE5}"
@@ -7342,7 +7342,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 6007725221889
+                                                "id": 162966456400018
                                             },
                                             "slotId": {
                                                 "m_id": "{BB73C160-3A27-4DC4-A45D-A285C1093467}"
@@ -7353,7 +7353,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6097919535105
+                                    "id": 163159729928338
                                 },
                                 "Name": "srcEndpoint=(ScriptCanvasPhysics_WorldFunctions_RayCastLocalSpaceWithGroup: Boolean: 0), destEndpoint=(If: Condition)",
                                 "Components": {
@@ -7362,7 +7362,7 @@
                                         "Id": 1783076537614904499,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5994840320001
+                                                "id": 163073830582418
                                             },
                                             "slotId": {
                                                 "m_id": "{7DA0F280-C0DC-4145-9F1F-2A03F9F9B164}"
@@ -7370,7 +7370,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5981955418113
+                                                "id": 163043765811346
                                             },
                                             "slotId": {
                                                 "m_id": "{91B1D5CC-3CB8-4843-84FC-5705B0737C94}"
@@ -7381,7 +7381,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6102214502401
+                                    "id": 163164024895634
                                 },
                                 "Name": "srcEndpoint=(ScriptCanvasPhysics_WorldFunctions_RayCastLocalSpaceWithGroup: Out), destEndpoint=(If: In)",
                                 "Components": {
@@ -7390,7 +7390,7 @@
                                         "Id": 13403609435798733283,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5994840320001
+                                                "id": 163073830582418
                                             },
                                             "slotId": {
                                                 "m_id": "{2BC8CA0F-BB2D-4EF5-9D58-A9EF4EDDBFCF}"
@@ -7398,7 +7398,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5981955418113
+                                                "id": 163043765811346
                                             },
                                             "slotId": {
                                                 "m_id": "{193B6221-B639-40E9-ADA0-56EDC3A8A786}"
@@ -7409,7 +7409,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6106509469697
+                                    "id": 163168319862930
                                 },
                                 "Name": "srcEndpoint=(If: True), destEndpoint=(HasTag: In)",
                                 "Components": {
@@ -7418,7 +7418,7 @@
                                         "Id": 12785734588627250834,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5981955418113
+                                                "id": 163043765811346
                                             },
                                             "slotId": {
                                                 "m_id": "{98FD4CFF-94B9-47D9-AAF6-5D509A9DBD22}"
@@ -7426,7 +7426,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 6003430254593
+                                                "id": 162992226203794
                                             },
                                             "slotId": {
                                                 "m_id": "{E9F69958-64BF-46F6-ADA0-9E53B26BA8F0}"
@@ -7437,7 +7437,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6110804436993
+                                    "id": 163172614830226
                                 },
                                 "Name": "srcEndpoint=(If: False), destEndpoint=(Set Variable: In)",
                                 "Components": {
@@ -7446,7 +7446,7 @@
                                         "Id": 961568738714868685,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5981955418113
+                                                "id": 163043765811346
                                             },
                                             "slotId": {
                                                 "m_id": "{5A3A6FE2-3537-46CB-9599-01443EC0A1A3}"
@@ -7454,7 +7454,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 6007725221889
+                                                "id": 162966456400018
                                             },
                                             "slotId": {
                                                 "m_id": "{BB73C160-3A27-4DC4-A45D-A285C1093467}"
@@ -7465,7 +7465,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6115099404289
+                                    "id": 163176909797522
                                 },
                                 "Name": "srcEndpoint=(ScriptCanvas_Vector3Functions_FromValues: Out), destEndpoint=(AddVelocity: In)",
                                 "Components": {
@@ -7474,7 +7474,7 @@
                                         "Id": 3861294589202743481,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5926120843265
+                                                "id": 162936391628946
                                             },
                                             "slotId": {
                                                 "m_id": "{55E9A020-F395-45CD-BAD3-2FA6F7BECF1A}"
@@ -7482,7 +7482,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5857401366529
+                                                "id": 163035175876754
                                             },
                                             "slotId": {
                                                 "m_id": "{4F7CBBC7-4EBE-4CC5-AB74-AF13D5654531}"
@@ -7493,7 +7493,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6119394371585
+                                    "id": 163181204764818
                                 },
                                 "Name": "srcEndpoint=(ScriptCanvas_Vector3Functions_FromValues: Vector3), destEndpoint=(AddVelocity: Vector3: 1)",
                                 "Components": {
@@ -7502,7 +7502,7 @@
                                         "Id": 1602160301543535752,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5926120843265
+                                                "id": 162936391628946
                                             },
                                             "slotId": {
                                                 "m_id": "{F494A76B-34F9-40C3-B38C-B1C807875959}"
@@ -7510,7 +7510,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5857401366529
+                                                "id": 163035175876754
                                             },
                                             "slotId": {
                                                 "m_id": "{CB592472-114B-4ACE-9BB3-93E6132D1C00}"
@@ -7521,7 +7521,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6123689338881
+                                    "id": 163185499732114
                                 },
                                 "Name": "srcEndpoint=(Set Variable: Number), destEndpoint=(ScriptCanvas_Vector3Functions_FromValues: Z)",
                                 "Components": {
@@ -7530,7 +7530,7 @@
                                         "Id": 4325317830314536419,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5973365483521
+                                                "id": 162919211759762
                                             },
                                             "slotId": {
                                                 "m_id": "{AEB07656-ED69-4054-90D9-C8FA827B9185}"
@@ -7538,7 +7538,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5926120843265
+                                                "id": 162936391628946
                                             },
                                             "slotId": {
                                                 "m_id": "{F8087FAC-9AAA-4649-8C0F-19CAA09CC188}"
@@ -7549,7 +7549,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6127984306177
+                                    "id": 163189794699410
                                 },
                                 "Name": "srcEndpoint=(Set Variable: Out), destEndpoint=(ScriptCanvas_Vector3Functions_FromValues: In)",
                                 "Components": {
@@ -7558,7 +7558,7 @@
                                         "Id": 5301725378248628610,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5973365483521
+                                                "id": 162919211759762
                                             },
                                             "slotId": {
                                                 "m_id": "{B24E1F33-D580-4E33-BE92-C820BA23398A}"
@@ -7566,7 +7566,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5926120843265
+                                                "id": 162936391628946
                                             },
                                             "slotId": {
                                                 "m_id": "{7EDEE8BB-DA21-446E-A96D-BA4B169EB9A5}"
@@ -7577,7 +7577,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6132279273473
+                                    "id": 163194089666706
                                 },
                                 "Name": "srcEndpoint=(Set Variable: Out), destEndpoint=(Set Gravity: In)",
                                 "Components": {
@@ -7586,7 +7586,7 @@
                                         "Id": 3016741118817755939,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 6016315156481
+                                                "id": 163026585942162
                                             },
                                             "slotId": {
                                                 "m_id": "{0F6531F7-B520-4FC4-B3A3-3969C74F4533}"
@@ -7594,7 +7594,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5853106399233
+                                                "id": 163013701040274
                                             },
                                             "slotId": {
                                                 "m_id": "{90DC99C2-06AB-4A53-89EF-24D9D8D23285}"
@@ -7605,7 +7605,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6136574240769
+                                    "id": 163198384634002
                                 },
                                 "Name": "srcEndpoint=(Set Variable: Out), destEndpoint=(Set Gravity: In)",
                                 "Components": {
@@ -7614,7 +7614,7 @@
                                         "Id": 10837265261910141446,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 6007725221889
+                                                "id": 162966456400018
                                             },
                                             "slotId": {
                                                 "m_id": "{0F6531F7-B520-4FC4-B3A3-3969C74F4533}"
@@ -7622,7 +7622,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5848811431937
+                                                "id": 163078125549714
                                             },
                                             "slotId": {
                                                 "m_id": "{90DC99C2-06AB-4A53-89EF-24D9D8D23285}"
@@ -7633,7 +7633,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6140869208065
+                                    "id": 163202679601298
                                 },
                                 "Name": "srcEndpoint=(On Graph Start: Out), destEndpoint=(Get Gravity: In)",
                                 "Components": {
@@ -7642,7 +7642,7 @@
                                         "Id": 3423147672087011608,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5964775548929
+                                                "id": 163048060778642
                                             },
                                             "slotId": {
                                                 "m_id": "{E0202752-0CD2-446F-A023-2847466F6B73}"
@@ -7650,7 +7650,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5917530908673
+                                                "id": 163095305418898
                                             },
                                             "slotId": {
                                                 "m_id": "{20C08B0E-726D-4B1F-9BC1-0ED082E55FF6}"
@@ -7661,7 +7661,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6145164175361
+                                    "id": 163206974568594
                                 },
                                 "Name": "srcEndpoint=(Get Gravity: Number), destEndpoint=(Set Variable: Number)",
                                 "Components": {
@@ -7670,7 +7670,7 @@
                                         "Id": 13160034445067969740,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5917530908673
+                                                "id": 163095305418898
                                             },
                                             "slotId": {
                                                 "m_id": "{4C760343-637E-45D8-94F8-2ABE2B50DE52}"
@@ -7678,7 +7678,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5943300712449
+                                                "id": 162987931236498
                                             },
                                             "slotId": {
                                                 "m_id": "{16677DF7-DB89-4A7E-AC12-1D16B4687BE7}"
@@ -7689,7 +7689,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6149459142657
+                                    "id": 163211269535890
                                 },
                                 "Name": "srcEndpoint=(Get Gravity: Out), destEndpoint=(Set Variable: In)",
                                 "Components": {
@@ -7698,7 +7698,7 @@
                                         "Id": 4579613338835202968,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5917530908673
+                                                "id": 163095305418898
                                             },
                                             "slotId": {
                                                 "m_id": "{8E0BF36C-458F-40E9-99D3-898FC8EA17D2}"
@@ -7706,7 +7706,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5943300712449
+                                                "id": 162987931236498
                                             },
                                             "slotId": {
                                                 "m_id": "{B4FA34EA-ABC7-44B5-8DBA-7BA1F7DC1081}"
@@ -7717,7 +7717,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6153754109953
+                                    "id": 163215564503186
                                 },
                                 "Name": "srcEndpoint=(Set Left Input Value: Out), destEndpoint=(Set Right Input Value: In)",
                                 "Components": {
@@ -7726,7 +7726,7 @@
                                         "Id": 8047294606261488697,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5896056072193
+                                                "id": 162949276530834
                                             },
                                             "slotId": {
                                                 "m_id": "{FF32E119-0CDC-4A6B-866F-F7C3110CDFF3}"
@@ -7734,7 +7734,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5900351039489
+                                                "id": 162910621825170
                                             },
                                             "slotId": {
                                                 "m_id": "{64CD0BA3-4163-4E1E-A682-3EC4D8BB5F32}"
@@ -7745,7 +7745,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6158049077249
+                                    "id": 163219859470482
                                 },
                                 "Name": "srcEndpoint=(Set Gravity: Out), destEndpoint=(Set Left Input Value: In)",
                                 "Components": {
@@ -7754,7 +7754,7 @@
                                         "Id": 5027148538692453082,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5853106399233
+                                                "id": 163013701040274
                                             },
                                             "slotId": {
                                                 "m_id": "{95806495-94B1-4029-801A-6CBEEFC05412}"
@@ -7762,7 +7762,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5896056072193
+                                                "id": 162949276530834
                                             },
                                             "slotId": {
                                                 "m_id": "{24D29C6C-983B-4646-B5C1-B8D374C68BE6}"
@@ -7773,7 +7773,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6162344044545
+                                    "id": 163224154437778
                                 },
                                 "Name": "srcEndpoint=(ScriptCanvasPhysics_WorldFunctions_RayCastLocalSpaceWithGroup: EntityId: 4), destEndpoint=(HasTag: EntityId: 0)",
                                 "Components": {
@@ -7782,7 +7782,7 @@
                                         "Id": 2807947104264475187,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5994840320001
+                                                "id": 163073830582418
                                             },
                                             "slotId": {
                                                 "m_id": "{155F68AB-E363-435C-94DE-967E93D7E1FC}"
@@ -7790,7 +7790,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 6003430254593
+                                                "id": 162992226203794
                                             },
                                             "slotId": {
                                                 "m_id": "{F1C69A06-50A3-442E-949F-202EF58275B9}"
@@ -7801,7 +7801,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6166639011841
+                                    "id": 163228449405074
                                 },
                                 "Name": "srcEndpoint=(Less Than (<): True), destEndpoint=(Set Forward Input Value: In)",
                                 "Components": {
@@ -7810,7 +7810,7 @@
                                         "Id": 9629989675595976289,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 6042084960257
+                                                "id": 162983636269202
                                             },
                                             "slotId": {
                                                 "m_id": "{A233A7BC-85A1-48B5-B565-03FD2CF4EAAD}"
@@ -7818,7 +7818,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 6020610123777
+                                                "id": 162897736923282
                                             },
                                             "slotId": {
                                                 "m_id": "{07B15DAA-90CB-4DF9-A559-667CD87FD333}"
@@ -7829,7 +7829,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6170933979137
+                                    "id": 163232744372370
                                 },
                                 "Name": "srcEndpoint=(ScriptCanvas_AABBFunctions_GetMax: Out), destEndpoint=(ScriptCanvas_Vector3Functions_GetElement: In)",
                                 "Components": {
@@ -7838,7 +7838,7 @@
                                         "Id": 4993127145326232406,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5999135287297
+                                                "id": 162962161432722
                                             },
                                             "slotId": {
                                                 "m_id": "{17DD42EB-AA31-4E3B-917C-502702507902}"
@@ -7846,7 +7846,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5956185614337
+                                                "id": 163091010451602
                                             },
                                             "slotId": {
                                                 "m_id": "{0EF289CA-B0F6-447C-84E9-16A2AACC5F7B}"
@@ -7857,7 +7857,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6175228946433
+                                    "id": 163237039339666
                                 },
                                 "Name": "srcEndpoint=(ScriptCanvas_AABBFunctions_GetMax: Vector3), destEndpoint=(ScriptCanvas_Vector3Functions_GetElement: Source)",
                                 "Components": {
@@ -7866,7 +7866,7 @@
                                         "Id": 10175707486885727634,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5999135287297
+                                                "id": 162962161432722
                                             },
                                             "slotId": {
                                                 "m_id": "{E9247D4D-4BA3-4B6E-8B69-3A374E51D6CC}"
@@ -7874,7 +7874,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5956185614337
+                                                "id": 163091010451602
                                             },
                                             "slotId": {
                                                 "m_id": "{3A08AD13-5721-43C5-975B-3E2A01A47943}"
@@ -7885,7 +7885,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6179523913729
+                                    "id": 163241334306962
                                 },
                                 "Name": "srcEndpoint=(GetWorldZ: Number), destEndpoint=(Less Than (<): Value A)",
                                 "Components": {
@@ -7894,7 +7894,7 @@
                                         "Id": 16832736111321790531,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5930415810561
+                                                "id": 163082420517010
                                             },
                                             "slotId": {
                                                 "m_id": "{62EEE68C-8DFD-4C6C-B733-A0CD5EE812AF}"
@@ -7902,7 +7902,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 6042084960257
+                                                "id": 162983636269202
                                             },
                                             "slotId": {
                                                 "m_id": "{E0E72745-4101-4189-94B3-CEFC8A026B65}"
@@ -7913,7 +7913,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6183818881025
+                                    "id": 163245629274258
                                 },
                                 "Name": "srcEndpoint=(Set Right Input Value: Out), destEndpoint=(GetWorldBounds: In)",
                                 "Components": {
@@ -7922,7 +7922,7 @@
                                         "Id": 4428726085404880760,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5900351039489
+                                                "id": 162910621825170
                                             },
                                             "slotId": {
                                                 "m_id": "{924DAC8E-35C5-40BB-972D-0A6D1AA4AD2F}"
@@ -7930,7 +7930,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5951890647041
+                                                "id": 163056650713234
                                             },
                                             "slotId": {
                                                 "m_id": "{A2F2F50B-4D7A-4432-ADB8-7F91BD0C548E}"
@@ -7941,7 +7941,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6188113848321
+                                    "id": 163249924241554
                                 },
                                 "Name": "srcEndpoint=(GetWorldBounds: Out), destEndpoint=(ScriptCanvas_AABBFunctions_GetMax: In)",
                                 "Components": {
@@ -7950,7 +7950,7 @@
                                         "Id": 13729393447532344763,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5951890647041
+                                                "id": 163056650713234
                                             },
                                             "slotId": {
                                                 "m_id": "{089F092B-E6FB-4868-A26F-A370B390EF8A}"
@@ -7958,7 +7958,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5999135287297
+                                                "id": 162962161432722
                                             },
                                             "slotId": {
                                                 "m_id": "{E018BACE-EA5F-4205-ABA5-A0A1B312737A}"
@@ -7969,7 +7969,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6192408815617
+                                    "id": 163254219208850
                                 },
                                 "Name": "srcEndpoint=(GetWorldBounds: AABB), destEndpoint=(ScriptCanvas_AABBFunctions_GetMax: Source)",
                                 "Components": {
@@ -7978,7 +7978,7 @@
                                         "Id": 824331725074128637,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5951890647041
+                                                "id": 163056650713234
                                             },
                                             "slotId": {
                                                 "m_id": "{D9229559-9E6A-4355-91A5-FFD8F592B64A}"
@@ -7986,7 +7986,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5999135287297
+                                                "id": 162962161432722
                                             },
                                             "slotId": {
                                                 "m_id": "{20776744-C3B3-4F3D-A87E-DFC54F22CF53}"
@@ -7997,7 +7997,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6196703782913
+                                    "id": 163258514176146
                                 },
                                 "Name": "srcEndpoint=(ScriptCanvasPhysics_WorldFunctions_RayCastLocalSpaceWithGroup: EntityId: 4), destEndpoint=(GetWorldBounds: EntityId)",
                                 "Components": {
@@ -8006,7 +8006,7 @@
                                         "Id": 8498269076945120649,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5994840320001
+                                                "id": 163073830582418
                                             },
                                             "slotId": {
                                                 "m_id": "{155F68AB-E363-435C-94DE-967E93D7E1FC}"
@@ -8014,7 +8014,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5951890647041
+                                                "id": 163056650713234
                                             },
                                             "slotId": {
                                                 "m_id": "{7A88D146-A656-4D58-9D49-16BD76A330B6}"
@@ -8025,7 +8025,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6200998750209
+                                    "id": 163262809143442
                                 },
                                 "Name": "srcEndpoint=(ScriptCanvas_Vector3Functions_GetElement: Out), destEndpoint=(Subtract (-): In)",
                                 "Components": {
@@ -8034,7 +8034,7 @@
                                         "Id": 11885423346611051329,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5956185614337
+                                                "id": 163091010451602
                                             },
                                             "slotId": {
                                                 "m_id": "{13D22968-F465-4E9E-A466-E0356BB8956E}"
@@ -8042,7 +8042,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5861696333825
+                                                "id": 162927801694354
                                             },
                                             "slotId": {
                                                 "m_id": "{A33F57CF-6CBB-47BE-8896-ED2090E3EDCC}"
@@ -8053,7 +8053,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6205293717505
+                                    "id": 163267104110738
                                 },
                                 "Name": "srcEndpoint=(ScriptCanvas_Vector3Functions_GetElement: Number), destEndpoint=(Subtract (-): Value 0)",
                                 "Components": {
@@ -8062,7 +8062,7 @@
                                         "Id": 15137608430545200712,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5956185614337
+                                                "id": 163091010451602
                                             },
                                             "slotId": {
                                                 "m_id": "{685ED851-95B6-4C13-A450-49E5DAB870A2}"
@@ -8070,7 +8070,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5861696333825
+                                                "id": 162927801694354
                                             },
                                             "slotId": {
                                                 "m_id": "{33C2E18A-8503-49F6-9086-DEBD7EE260B6}"
@@ -8081,7 +8081,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6209588684801
+                                    "id": 163271399078034
                                 },
                                 "Name": "srcEndpoint=(Subtract (-): Result), destEndpoint=(Less Than (<): Value B)",
                                 "Components": {
@@ -8090,7 +8090,7 @@
                                         "Id": 15765218057087128047,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5861696333825
+                                                "id": 162927801694354
                                             },
                                             "slotId": {
                                                 "m_id": "{AA370F0B-B0C0-429F-9B30-8590A6C6C8F8}"
@@ -8098,7 +8098,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 6042084960257
+                                                "id": 162983636269202
                                             },
                                             "slotId": {
                                                 "m_id": "{62567DE7-AB67-434C-8174-177545F1E0A2}"
@@ -8109,7 +8109,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6213883652097
+                                    "id": 163275694045330
                                 },
                                 "Name": "srcEndpoint=(Subtract (-): Out), destEndpoint=(GetWorldZ: In)",
                                 "Components": {
@@ -8118,7 +8118,7 @@
                                         "Id": 10343094261916875295,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5861696333825
+                                                "id": 162927801694354
                                             },
                                             "slotId": {
                                                 "m_id": "{6CCA37EC-F587-434E-8E4C-05C553561D2B}"
@@ -8126,7 +8126,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5930415810561
+                                                "id": 163082420517010
                                             },
                                             "slotId": {
                                                 "m_id": "{400A1D56-292D-4CFC-A9A3-74DA86D9C55A}"
@@ -8137,7 +8137,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6218178619393
+                                    "id": 163279989012626
                                 },
                                 "Name": "srcEndpoint=(TickBus Handler: ExecutionSlot:OnTick), destEndpoint=(InputHandler: Connect Event)",
                                 "Components": {
@@ -8146,7 +8146,7 @@
                                         "Id": 10756746090409955555,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5947595679745
+                                                "id": 162979341301906
                                             },
                                             "slotId": {
                                                 "m_id": "{1D526426-987A-457D-B6E0-297A23A2616A}"
@@ -8154,7 +8154,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5934710777857
+                                                "id": 163099600386194
                                             },
                                             "slotId": {
                                                 "m_id": "{DF6E278A-69A9-490F-88AA-16D47D6617C2}"
@@ -8165,7 +8165,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6222473586689
+                                    "id": 163284283979922
                                 },
                                 "Name": "srcEndpoint=(InputHandler: Held), destEndpoint=(If: In)",
                                 "Components": {
@@ -8174,7 +8174,7 @@
                                         "Id": 847498006291586020,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5934710777857
+                                                "id": 163099600386194
                                             },
                                             "slotId": {
                                                 "m_id": "{B687959F-506F-4E24-9CD7-C75EC681C276}"
@@ -8182,7 +8182,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5865991301121
+                                                "id": 163086715484306
                                             },
                                             "slotId": {
                                                 "m_id": "{19610F12-7A5D-472A-8E4A-70D8D148B9FE}"
@@ -8193,7 +8193,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6226768553985
+                                    "id": 163288578947218
                                 },
                                 "Name": "srcEndpoint=(If: True), destEndpoint=(Get Camera Pitch: In)",
                                 "Components": {
@@ -8202,7 +8202,7 @@
                                         "Id": 7074212605842005772,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5865991301121
+                                                "id": 163086715484306
                                             },
                                             "slotId": {
                                                 "m_id": "{AF8624B7-1B3A-4525-8F9C-D4644A825364}"
@@ -8210,7 +8210,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5913235941377
+                                                "id": 162923506727058
                                             },
                                             "slotId": {
                                                 "m_id": "{6BC6115D-8ABB-4300-BF3F-8D4D52C385F8}"
@@ -8221,7 +8221,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6231063521281
+                                    "id": 163292873914514
                                 },
                                 "Name": "srcEndpoint=(GetWorldZ: Out), destEndpoint=(Less Than (<): In)",
                                 "Components": {
@@ -8230,7 +8230,7 @@
                                         "Id": 8316555507266249858,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5930415810561
+                                                "id": 163082420517010
                                             },
                                             "slotId": {
                                                 "m_id": "{B9351BBC-E1F8-49EC-BCF2-B58ED6E85597}"
@@ -8238,7 +8238,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 6042084960257
+                                                "id": 162983636269202
                                             },
                                             "slotId": {
                                                 "m_id": "{C2EAB130-B4F0-4562-8A21-3164496CA92E}"
@@ -8249,7 +8249,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6235358488577
+                                    "id": 163297168881810
                                 },
                                 "Name": "srcEndpoint=(TickBus Handler: ExecutionSlot:OnTick), destEndpoint=(ScriptCanvasPhysics_WorldFunctions_RayCastLocalSpaceWithGroup: In)",
                                 "Components": {
@@ -8258,7 +8258,7 @@
                                         "Id": 6883880535411007096,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5947595679745
+                                                "id": 162979341301906
                                             },
                                             "slotId": {
                                                 "m_id": "{1D526426-987A-457D-B6E0-297A23A2616A}"
@@ -8266,7 +8266,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5986250385409
+                                                "id": 163005111105682
                                             },
                                             "slotId": {
                                                 "m_id": "{1187B21C-F2D4-4F34-9008-920C7A1C2225}"
@@ -8277,7 +8277,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6239653455873
+                                    "id": 163301463849106
                                 },
                                 "Name": "srcEndpoint=(ScriptCanvasPhysics_WorldFunctions_RayCastLocalSpaceWithGroup: Out), destEndpoint=(If: In)",
                                 "Components": {
@@ -8286,7 +8286,7 @@
                                         "Id": 6299161491584037674,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5986250385409
+                                                "id": 163005111105682
                                             },
                                             "slotId": {
                                                 "m_id": "{2BC8CA0F-BB2D-4EF5-9D58-A9EF4EDDBFCF}"
@@ -8294,7 +8294,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5921825875969
+                                                "id": 162932096661650
                                             },
                                             "slotId": {
                                                 "m_id": "{193B6221-B639-40E9-ADA0-56EDC3A8A786}"
@@ -8305,7 +8305,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6243948423169
+                                    "id": 163305758816402
                                 },
                                 "Name": "srcEndpoint=(ScriptCanvasPhysics_WorldFunctions_RayCastLocalSpaceWithGroup: Boolean: 0), destEndpoint=(If: Condition)",
                                 "Components": {
@@ -8314,7 +8314,7 @@
                                         "Id": 14219923379039175081,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5986250385409
+                                                "id": 163005111105682
                                             },
                                             "slotId": {
                                                 "m_id": "{7DA0F280-C0DC-4145-9F1F-2A03F9F9B164}"
@@ -8322,7 +8322,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5921825875969
+                                                "id": 162932096661650
                                             },
                                             "slotId": {
                                                 "m_id": "{91B1D5CC-3CB8-4843-84FC-5705B0737C94}"
@@ -8333,7 +8333,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6248243390465
+                                    "id": 163310053783698
                                 },
                                 "Name": "srcEndpoint=(ScriptCanvasPhysics_WorldFunctions_RayCastLocalSpaceWithGroup: EntityId: 4), destEndpoint=(HasTag: EntityId: 0)",
                                 "Components": {
@@ -8342,7 +8342,7 @@
                                         "Id": 9344025950293419683,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5986250385409
+                                                "id": 163005111105682
                                             },
                                             "slotId": {
                                                 "m_id": "{155F68AB-E363-435C-94DE-967E93D7E1FC}"
@@ -8350,7 +8350,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5960480581633
+                                                "id": 162906326857874
                                             },
                                             "slotId": {
                                                 "m_id": "{F1C69A06-50A3-442E-949F-202EF58275B9}"
@@ -8361,7 +8361,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6252538357761
+                                    "id": 163314348750994
                                 },
                                 "Name": "srcEndpoint=(HasTag: Out), destEndpoint=(If: In)",
                                 "Components": {
@@ -8370,7 +8370,7 @@
                                         "Id": 11759221337591341389,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5960480581633
+                                                "id": 162906326857874
                                             },
                                             "slotId": {
                                                 "m_id": "{E54D49AE-81AE-4B02-B219-BE2951A0527F}"
@@ -8378,7 +8378,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5874581235713
+                                                "id": 163022290974866
                                             },
                                             "slotId": {
                                                 "m_id": "{6878D29B-1758-4EFF-A031-6BBD6732D5EA}"
@@ -8389,7 +8389,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6256833325057
+                                    "id": 163318643718290
                                 },
                                 "Name": "srcEndpoint=(HasTag: Boolean), destEndpoint=(If: Condition)",
                                 "Components": {
@@ -8398,7 +8398,7 @@
                                         "Id": 1210757777553627924,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5960480581633
+                                                "id": 162906326857874
                                             },
                                             "slotId": {
                                                 "m_id": "{270932F5-D9F2-4FC5-B88E-ECE6A1D111B6}"
@@ -8406,7 +8406,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5874581235713
+                                                "id": 163022290974866
                                             },
                                             "slotId": {
                                                 "m_id": "{7B94BE53-EB60-43F4-ABEF-59E530376E10}"
@@ -8417,7 +8417,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6261128292353
+                                    "id": 163322938685586
                                 },
                                 "Name": "srcEndpoint=(If: True), destEndpoint=(GetVelocity: In)",
                                 "Components": {
@@ -8426,7 +8426,7 @@
                                         "Id": 9312842610440185415,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5874581235713
+                                                "id": 163022290974866
                                             },
                                             "slotId": {
                                                 "m_id": "{03486954-997F-4C6A-9C20-A766753E903E}"
@@ -8434,7 +8434,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5870286268417
+                                                "id": 162940686596242
                                             },
                                             "slotId": {
                                                 "m_id": "{DC8A9233-A675-4077-A8CF-13C65964DB2D}"
@@ -8445,7 +8445,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6265423259649
+                                    "id": 163327233652882
                                 },
                                 "Name": "srcEndpoint=(GetVelocity: Out), destEndpoint=(ScriptCanvas_Vector3Functions_GetElement: In)",
                                 "Components": {
@@ -8454,7 +8454,7 @@
                                         "Id": 7617630793371499605,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5870286268417
+                                                "id": 162940686596242
                                             },
                                             "slotId": {
                                                 "m_id": "{8BADF622-7F8D-4D2E-91D8-418B6AC429FA}"
@@ -8462,7 +8462,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5990545352705
+                                                "id": 163065240647826
                                             },
                                             "slotId": {
                                                 "m_id": "{2A4CDBD2-1582-4EE7-948A-1ECA9E3B5455}"
@@ -8473,7 +8473,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6269718226945
+                                    "id": 163331528620178
                                 },
                                 "Name": "srcEndpoint=(GetVelocity: Vector3), destEndpoint=(ScriptCanvas_Vector3Functions_GetElement: Source)",
                                 "Components": {
@@ -8482,7 +8482,7 @@
                                         "Id": 9262696538054598818,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5870286268417
+                                                "id": 162940686596242
                                             },
                                             "slotId": {
                                                 "m_id": "{89D523F6-52BF-4A72-BB84-7A4B725300E7}"
@@ -8490,7 +8490,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5990545352705
+                                                "id": 163065240647826
                                             },
                                             "slotId": {
                                                 "m_id": "{900298B1-CFB3-4B47-9D4F-09DEE1A01426}"
@@ -8501,7 +8501,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6274013194241
+                                    "id": 163335823587474
                                 },
                                 "Name": "srcEndpoint=(ScriptCanvas_Vector3Functions_GetElement: Number), destEndpoint=(Less Than (<): Value A)",
                                 "Components": {
@@ -8510,7 +8510,7 @@
                                         "Id": 4788766697004713013,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5990545352705
+                                                "id": 163065240647826
                                             },
                                             "slotId": {
                                                 "m_id": "{A4B9F922-D925-4EF5-8006-8E5DA55A2275}"
@@ -8518,7 +8518,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 6037789992961
+                                                "id": 162975046334610
                                             },
                                             "slotId": {
                                                 "m_id": "{B15B4EDE-ECE1-4CCF-BDDB-45B5CCE3F4E4}"
@@ -8529,7 +8529,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6278308161537
+                                    "id": 163340118554770
                                 },
                                 "Name": "srcEndpoint=(ScriptCanvas_Vector3Functions_GetElement: Out), destEndpoint=(Less Than (<): In)",
                                 "Components": {
@@ -8538,7 +8538,7 @@
                                         "Id": 4497063588141783797,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5990545352705
+                                                "id": 163065240647826
                                             },
                                             "slotId": {
                                                 "m_id": "{7067201C-054A-4D44-A932-A408B2CA7D46}"
@@ -8546,7 +8546,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 6037789992961
+                                                "id": 162975046334610
                                             },
                                             "slotId": {
                                                 "m_id": "{277F5C71-A69D-48D7-878B-1F2F77E063B3}"
@@ -8557,7 +8557,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6282603128833
+                                    "id": 163344413522066
                                 },
                                 "Name": "srcEndpoint=(ScriptCanvas_Vector3Functions_GetElement: Number), destEndpoint=(Multiply (*): Value 0)",
                                 "Components": {
@@ -8566,7 +8566,7 @@
                                         "Id": 7509959039282837953,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5990545352705
+                                                "id": 163065240647826
                                             },
                                             "slotId": {
                                                 "m_id": "{A4B9F922-D925-4EF5-8006-8E5DA55A2275}"
@@ -8574,7 +8574,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5908940974081
+                                                "id": 162953571498130
                                             },
                                             "slotId": {
                                                 "m_id": "{5045581C-0977-49C9-80D9-53C5AEFA3876}"
@@ -8585,7 +8585,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6286898096129
+                                    "id": 163348708489362
                                 },
                                 "Name": "srcEndpoint=(Less Than (<): True), destEndpoint=(Multiply (*): In)",
                                 "Components": {
@@ -8594,7 +8594,7 @@
                                         "Id": 8878641098911869171,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 6037789992961
+                                                "id": 162975046334610
                                             },
                                             "slotId": {
                                                 "m_id": "{99393DC1-D769-4D9F-A02D-974965501A29}"
@@ -8602,7 +8602,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5908940974081
+                                                "id": 162953571498130
                                             },
                                             "slotId": {
                                                 "m_id": "{93586417-E75D-44DB-9A7E-172A3361FB7C}"
@@ -8613,7 +8613,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6291193063425
+                                    "id": 163353003456658
                                 },
                                 "Name": "srcEndpoint=(Multiply (*): Out), destEndpoint=(Set Apply Velocity Z: In)",
                                 "Components": {
@@ -8622,7 +8622,7 @@
                                         "Id": 4064363984240970927,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5908940974081
+                                                "id": 162953571498130
                                             },
                                             "slotId": {
                                                 "m_id": "{4C545908-88B3-4726-9B23-4F59D180037F}"
@@ -8630,7 +8630,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 6024905091073
+                                                "id": 162902031890578
                                             },
                                             "slotId": {
                                                 "m_id": "{3A522CFA-018A-4BA2-948B-C8F75EE41283}"
@@ -8641,7 +8641,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6295488030721
+                                    "id": 163357298423954
                                 },
                                 "Name": "srcEndpoint=(Multiply (*): Result), destEndpoint=(Set Apply Velocity Z: Number: 1)",
                                 "Components": {
@@ -8650,7 +8650,7 @@
                                         "Id": 4375344374448146475,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5908940974081
+                                                "id": 162953571498130
                                             },
                                             "slotId": {
                                                 "m_id": "{9F42DC67-637F-4301-9019-460FC01DE2B6}"
@@ -8658,7 +8658,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 6024905091073
+                                                "id": 162902031890578
                                             },
                                             "slotId": {
                                                 "m_id": "{A1C48452-841F-4E17-A978-2483FE2CFB9D}"
@@ -8669,7 +8669,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 6299782998017
+                                    "id": 163361593391250
                                 },
                                 "Name": "srcEndpoint=(If: True), destEndpoint=(HasTag: In)",
                                 "Components": {
@@ -8678,7 +8678,7 @@
                                         "Id": 14574254987728533373,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5921825875969
+                                                "id": 162932096661650
                                             },
                                             "slotId": {
                                                 "m_id": "{98FD4CFF-94B9-47D9-AAF6-5D509A9DBD22}"
@@ -8686,7 +8686,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5960480581633
+                                                "id": 162906326857874
                                             },
                                             "slotId": {
                                                 "m_id": "{E9F69958-64BF-46F6-ADA0-9E53B26BA8F0}"
@@ -8697,7 +8697,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 153904924059649
+                                    "id": 163365888358546
                                 },
                                 "Name": "srcEndpoint=(ScriptCanvasPhysics_WorldFunctions_RayCastLocalSpaceWithGroup: Out), destEndpoint=(If: In)",
                                 "Components": {
@@ -8706,7 +8706,7 @@
                                         "Id": 1850583018301636819,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 144911262541825
+                                                "id": 163017996007570
                                             },
                                             "slotId": {
                                                 "m_id": "{2BC8CA0F-BB2D-4EF5-9D58-A9EF4EDDBFCF}"
@@ -8714,7 +8714,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 144902672607233
+                                                "id": 162944981563538
                                             },
                                             "slotId": {
                                                 "m_id": "{BB2105D9-69E5-4533-A554-0C53EF885ECE}"
@@ -8725,7 +8725,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 153977938503681
+                                    "id": 163370183325842
                                 },
                                 "Name": "srcEndpoint=(If: False), destEndpoint=(Not Equal To (!=): In)",
                                 "Components": {
@@ -8734,7 +8734,7 @@
                                         "Id": 15683779053815203774,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 144902672607233
+                                                "id": 162944981563538
                                             },
                                             "slotId": {
                                                 "m_id": "{CF8043B0-2C84-47CC-B9F6-7C42641014BA}"
@@ -8742,7 +8742,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 144898377639937
+                                                "id": 163030880909458
                                             },
                                             "slotId": {
                                                 "m_id": "{8B9A1DA4-5866-4989-BFE2-5F4CC863701D}"
@@ -8753,7 +8753,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 154050952947713
+                                    "id": 163374478293138
                                 },
                                 "Name": "srcEndpoint=(GetCollisionGroupName: Out), destEndpoint=(Not Equal To (!=): In)",
                                 "Components": {
@@ -8762,7 +8762,7 @@
                                         "Id": 15281174930163918138,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 144906967574529
+                                                "id": 163103895353490
                                             },
                                             "slotId": {
                                                 "m_id": "{5F9CEF7D-0E51-415A-BB4E-B183016D7C1C}"
@@ -8770,7 +8770,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 144885492738049
+                                                "id": 163039470844050
                                             },
                                             "slotId": {
                                                 "m_id": "{89BA0EB4-41BB-475D-A987-51260F4C9872}"
@@ -8781,7 +8781,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 154123967391745
+                                    "id": 163378773260434
                                 },
                                 "Name": "srcEndpoint=(Not Equal To (!=): True), destEndpoint=(Set Variable: In)",
                                 "Components": {
@@ -8790,7 +8790,7 @@
                                         "Id": 2827265788810778569,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 144885492738049
+                                                "id": 163039470844050
                                             },
                                             "slotId": {
                                                 "m_id": "{52700A7D-775C-4803-B0F2-BAF9AFFE481F}"
@@ -8798,7 +8798,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 144919852476417
+                                                "id": 163052355745938
                                             },
                                             "slotId": {
                                                 "m_id": "{8AA26B44-218F-4522-BFCF-82B5AD1823AA}"
@@ -8809,7 +8809,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 154196981835777
+                                    "id": 163383068227730
                                 },
                                 "Name": "srcEndpoint=(If: True), destEndpoint=(GetParentId: In)",
                                 "Components": {
@@ -8818,7 +8818,7 @@
                                         "Id": 4354278806655638409,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 144902672607233
+                                                "id": 162944981563538
                                             },
                                             "slotId": {
                                                 "m_id": "{054CAF53-14EA-4B1F-81D1-160C78E44EA3}"
@@ -8826,7 +8826,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 144889787705345
+                                                "id": 162996521171090
                                             },
                                             "slotId": {
                                                 "m_id": "{EB29FFBC-5B03-40A9-B42F-59011CA84A11}"
@@ -8837,7 +8837,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 154269996279809
+                                    "id": 163387363195026
                                 },
                                 "Name": "srcEndpoint=(ScriptCanvasPhysics_WorldFunctions_RayCastLocalSpaceWithGroup: Boolean: 0), destEndpoint=(If: Condition)",
                                 "Components": {
@@ -8846,7 +8846,7 @@
                                         "Id": 6365943578468898537,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 144911262541825
+                                                "id": 163017996007570
                                             },
                                             "slotId": {
                                                 "m_id": "{7DA0F280-C0DC-4145-9F1F-2A03F9F9B164}"
@@ -8854,7 +8854,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 144902672607233
+                                                "id": 162944981563538
                                             },
                                             "slotId": {
                                                 "m_id": "{4BC79E42-CE63-4F64-B83B-492370267DAD}"
@@ -8865,7 +8865,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 154343010723841
+                                    "id": 163391658162322
                                 },
                                 "Name": "srcEndpoint=(GetParentId: Out), destEndpoint=(Not Equal To (!=): In)",
                                 "Components": {
@@ -8874,7 +8874,7 @@
                                         "Id": 12934160013299524583,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 144894082672641
+                                                "id": 163069535615122
                                             },
                                             "slotId": {
                                                 "m_id": "{6A43F0EE-0183-4D66-B078-8A9FCDBE381F}"
@@ -8882,7 +8882,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 144915557509121
+                                                "id": 163009406072978
                                             },
                                             "slotId": {
                                                 "m_id": "{DC267475-6BB6-46B9-8AB7-D518CD053F71}"
@@ -8893,7 +8893,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 154416025167873
+                                    "id": 163395953129618
                                 },
                                 "Name": "srcEndpoint=(Not Equal To (!=): True), destEndpoint=(SetParent: In)",
                                 "Components": {
@@ -8902,7 +8902,7 @@
                                         "Id": 15814816005445289139,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 144915557509121
+                                                "id": 163009406072978
                                             },
                                             "slotId": {
                                                 "m_id": "{E1FCB8BC-965C-448A-86F2-1F4E8FFB319D}"
@@ -8910,7 +8910,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 144872607836161
+                                                "id": 163000816138386
                                             },
                                             "slotId": {
                                                 "m_id": "{1C46D899-7091-4678-B09C-C47D54687421}"
@@ -8921,7 +8921,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 154489039611905
+                                    "id": 163400248096914
                                 },
                                 "Name": "srcEndpoint=(Not Equal To (!=): True), destEndpoint=(GetParentId: In)",
                                 "Components": {
@@ -8930,7 +8930,7 @@
                                         "Id": 18310782123872999388,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 144898377639937
+                                                "id": 163030880909458
                                             },
                                             "slotId": {
                                                 "m_id": "{71228F30-B34C-426B-A386-FC149F12779B}"
@@ -8938,7 +8938,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 144894082672641
+                                                "id": 163069535615122
                                             },
                                             "slotId": {
                                                 "m_id": "{EB29FFBC-5B03-40A9-B42F-59011CA84A11}"
@@ -8949,7 +8949,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 154562054055937
+                                    "id": 163404543064210
                                 },
                                 "Name": "srcEndpoint=(GetParentId: EntityId), destEndpoint=(GetCollisionGroupName: EntityId)",
                                 "Components": {
@@ -8958,7 +8958,7 @@
                                         "Id": 4680060010650279388,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 144889787705345
+                                                "id": 162996521171090
                                             },
                                             "slotId": {
                                                 "m_id": "{79C9FC19-8A17-4528-98AA-558C3945C37E}"
@@ -8966,7 +8966,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 144906967574529
+                                                "id": 163103895353490
                                             },
                                             "slotId": {
                                                 "m_id": "{94ACA6B1-9FEE-4093-892B-C4E1F4275109}"
@@ -8977,7 +8977,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 154635068499969
+                                    "id": 163408838031506
                                 },
                                 "Name": "srcEndpoint=(GetParentId: EntityId), destEndpoint=(Set Variable: EntityId)",
                                 "Components": {
@@ -8986,7 +8986,7 @@
                                         "Id": 4830724431446357039,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 144889787705345
+                                                "id": 162996521171090
                                             },
                                             "slotId": {
                                                 "m_id": "{79C9FC19-8A17-4528-98AA-558C3945C37E}"
@@ -8994,7 +8994,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 144919852476417
+                                                "id": 163052355745938
                                             },
                                             "slotId": {
                                                 "m_id": "{28A83A40-992A-41C7-9711-7FDE39AB9B00}"
@@ -9005,7 +9005,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 154686608107521
+                                    "id": 163413132998802
                                 },
                                 "Name": "srcEndpoint=(GetParentId: EntityId), destEndpoint=(Not Equal To (!=): Value A)",
                                 "Components": {
@@ -9014,7 +9014,7 @@
                                         "Id": 5153654439757451788,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 144889787705345
+                                                "id": 162996521171090
                                             },
                                             "slotId": {
                                                 "m_id": "{79C9FC19-8A17-4528-98AA-558C3945C37E}"
@@ -9022,7 +9022,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 144876902803457
+                                                "id": 162970751367314
                                             },
                                             "slotId": {
                                                 "m_id": "{A595BD30-DC15-4572-B108-EE13939D4B10}"
@@ -9033,7 +9033,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 154738147715073
+                                    "id": 163417427966098
                                 },
                                 "Name": "srcEndpoint=(GetParentId: EntityId), destEndpoint=(Not Equal To (!=): Value A)",
                                 "Components": {
@@ -9042,7 +9042,7 @@
                                         "Id": 9180317670633583267,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 144894082672641
+                                                "id": 163069535615122
                                             },
                                             "slotId": {
                                                 "m_id": "{79C9FC19-8A17-4528-98AA-558C3945C37E}"
@@ -9050,7 +9050,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 144915557509121
+                                                "id": 163009406072978
                                             },
                                             "slotId": {
                                                 "m_id": "{A595BD30-DC15-4572-B108-EE13939D4B10}"
@@ -9061,7 +9061,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 154811162159105
+                                    "id": 163421722933394
                                 },
                                 "Name": "srcEndpoint=(GetCollisionGroupName: String), destEndpoint=(Not Equal To (!=): Value A)",
                                 "Components": {
@@ -9070,7 +9070,7 @@
                                         "Id": 11579272394013789901,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 144906967574529
+                                                "id": 163103895353490
                                             },
                                             "slotId": {
                                                 "m_id": "{5EC0FCAA-587E-424B-8C86-4FA08007A8CA}"
@@ -9078,7 +9078,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 144885492738049
+                                                "id": 163039470844050
                                             },
                                             "slotId": {
                                                 "m_id": "{5B68BB8D-038A-4F7F-A245-979322F59E33}"
@@ -9089,7 +9089,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 154884176603137
+                                    "id": 163426017900690
                                 },
                                 "Name": "srcEndpoint=(Set Variable: Out), destEndpoint=(SetParent: In)",
                                 "Components": {
@@ -9098,7 +9098,7 @@
                                         "Id": 9764717965273756957,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 144919852476417
+                                                "id": 163052355745938
                                             },
                                             "slotId": {
                                                 "m_id": "{AA6BDF59-576E-4D9C-B2D2-94D03EE8CF9F}"
@@ -9106,7 +9106,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 144881197770753
+                                                "id": 163108190320786
                                             },
                                             "slotId": {
                                                 "m_id": "{5EBF1789-BF6F-40E2-BA84-8C0FFCA61DDD}"
@@ -9117,7 +9117,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 154957191047169
+                                    "id": 163430312867986
                                 },
                                 "Name": "srcEndpoint=(Not Equal To (!=): True), destEndpoint=(GetCollisionGroupName: In)",
                                 "Components": {
@@ -9126,7 +9126,7 @@
                                         "Id": 512558944727821810,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 144876902803457
+                                                "id": 162970751367314
                                             },
                                             "slotId": {
                                                 "m_id": "{E1FCB8BC-965C-448A-86F2-1F4E8FFB319D}"
@@ -9134,7 +9134,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 144906967574529
+                                                "id": 163103895353490
                                             },
                                             "slotId": {
                                                 "m_id": "{BFA82568-9E70-4CE7-A4C9-D45BF5ED9AB4}"
@@ -9145,7 +9145,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 155030205491201
+                                    "id": 163434607835282
                                 },
                                 "Name": "srcEndpoint=(ScriptCanvasPhysics_WorldFunctions_RayCastLocalSpaceWithGroup: EntityId: 4), destEndpoint=(Not Equal To (!=): Value B)",
                                 "Components": {
@@ -9154,7 +9154,7 @@
                                         "Id": 6082774402953115303,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 144911262541825
+                                                "id": 163017996007570
                                             },
                                             "slotId": {
                                                 "m_id": "{155F68AB-E363-435C-94DE-967E93D7E1FC}"
@@ -9162,7 +9162,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 144876902803457
+                                                "id": 162970751367314
                                             },
                                             "slotId": {
                                                 "m_id": "{E064F07A-F933-493A-96DA-DF9930B4764A}"
@@ -9173,7 +9173,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 155103219935233
+                                    "id": 163438902802578
                                 },
                                 "Name": "srcEndpoint=(ScriptCanvasPhysics_WorldFunctions_RayCastLocalSpaceWithGroup: EntityId: 4), destEndpoint=(SetParent: EntityId: 1)",
                                 "Components": {
@@ -9182,7 +9182,7 @@
                                         "Id": 12435314599464962256,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 144911262541825
+                                                "id": 163017996007570
                                             },
                                             "slotId": {
                                                 "m_id": "{155F68AB-E363-435C-94DE-967E93D7E1FC}"
@@ -9190,7 +9190,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 144881197770753
+                                                "id": 163108190320786
                                             },
                                             "slotId": {
                                                 "m_id": "{1464C399-3B47-465A-AAA9-97C323DA9A41}"
@@ -9201,7 +9201,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 155154759542785
+                                    "id": 163443197769874
                                 },
                                 "Name": "srcEndpoint=(GetParentId: Out), destEndpoint=(Not Equal To (!=): In)",
                                 "Components": {
@@ -9210,7 +9210,7 @@
                                         "Id": 1248593558760453733,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 144889787705345
+                                                "id": 162996521171090
                                             },
                                             "slotId": {
                                                 "m_id": "{6A43F0EE-0183-4D66-B078-8A9FCDBE381F}"
@@ -9218,7 +9218,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 144876902803457
+                                                "id": 162970751367314
                                             },
                                             "slotId": {
                                                 "m_id": "{DC267475-6BB6-46B9-8AB7-D518CD053F71}"
@@ -9229,7 +9229,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 172051160885249
+                                    "id": 163447492737170
                                 },
                                 "Name": "srcEndpoint=(TickBus Handler: ExecutionSlot:OnTick), destEndpoint=(ScriptCanvasPhysics_WorldFunctions_RayCastLocalSpaceWithGroup: In)",
                                 "Components": {
@@ -9238,7 +9238,7 @@
                                         "Id": 14809350127908595591,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5947595679745
+                                                "id": 162979341301906
                                             },
                                             "slotId": {
                                                 "m_id": "{1D526426-987A-457D-B6E0-297A23A2616A}"
@@ -9246,7 +9246,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 144911262541825
+                                                "id": 163017996007570
                                             },
                                             "slotId": {
                                                 "m_id": "{1187B21C-F2D4-4F34-9008-920C7A1C2225}"
@@ -9266,13 +9266,49 @@
                     "GraphCanvasData": [
                         {
                             "Key": {
-                                "id": 5844516464641
+                                "id": 162893441955986
                             },
                             "Value": {
                                 "ComponentData": {
                                     "{5F84B500-8C45-40D1-8EFC-A5306B241444}": {
                                         "$type": "SceneComponentSaveData",
                                         "Constructs": [
+                                            {
+                                                "Type": 1,
+                                                "DataContainer": {
+                                                    "ComponentData": {
+                                                        "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                                            "$type": "NodeSaveData"
+                                                        },
+                                                        "{524D8380-AC09-444E-870E-9CEF2535B4A2}": {
+                                                            "$type": "CommentNodeTextSaveData",
+                                                            "Comment": "How to use VertMovement script canvas\n\nAdd this script canvas to the player as a script canvas component.\n\nEnsure ladders have static rigidbody box collider, then add tag \"Ladder\" to them\nEnjoy climbing up ladders\n\nEnsure trampolines have static rigidbody box collider, then add tag \"Tramp\" to them\nEnjoy jumping on trampolines\n\nEnsure any elevators have either the collision layer set to \"MovingPlatform\" or a child static rigidbody trigger collider with the TriggerParent script canvas attatched. Both solutions work.\nEnjoy riding moving platforms\n\n",
+                                                            "BackgroundColor": [
+                                                                0.9800000190734863,
+                                                                0.9700000286102295,
+                                                                0.6499999761581421
+                                                            ],
+                                                            "FontSettings": {
+                                                                "PixelSize": 16
+                                                            }
+                                                        },
+                                                        "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                                            "$type": "GeometrySaveData",
+                                                            "Position": [
+                                                                0.0,
+                                                                -300.0
+                                                            ]
+                                                        },
+                                                        "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                                            "$type": "StylingComponentSaveData"
+                                                        },
+                                                        "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                                            "$type": "PersistentIdComponentSaveData",
+                                                            "PersistentId": "{5E4D81D1-2B17-4D31-AAB7-F0D08BA5FCD2}"
+                                                        }
+                                                    }
+                                                }
+                                            },
                                             {
                                                 "Type": 3,
                                                 "DataContainer": {
@@ -9282,11 +9318,11 @@
                                                         },
                                                         "{524D8380-AC09-444E-870E-9CEF2535B4A2}": {
                                                             "$type": "CommentNodeTextSaveData",
-                                                            "Comment": "ElevatorPlatformCheck",
+                                                            "Comment": "Trampoline Check",
                                                             "BackgroundColor": [
-                                                                0.8843518495559692,
-                                                                0.658823549747467,
-                                                                0.4480659067630768
+                                                                0.9800000190734863,
+                                                                0.9700000286102295,
+                                                                0.6499999761581421
                                                             ],
                                                             "FontSettings": {
                                                                 "PixelSize": 16
@@ -9294,28 +9330,25 @@
                                                         },
                                                         "{6F4811ED-BD83-4A2A-8831-58EEA4020D57}": {
                                                             "$type": "NodeGroupFrameComponentSaveData",
-                                                            "DisplayHeight": 580.0,
-                                                            "DisplayWidth": 3420.0,
+                                                            "DisplayHeight": 387.0,
+                                                            "DisplayWidth": 3440.0,
                                                             "PersistentGroupedId": [
-                                                                "{25673CF9-B568-4602-9A33-E406D275511E}",
-                                                                "{F96E318E-0993-46B7-995B-99D0981B4FB4}",
-                                                                "{F5235CFC-EE59-4042-8C3A-FFE8D34AC816}",
-                                                                "{09FE5056-1446-466E-9551-E9BBD7D19F31}",
-                                                                "{9C9FF66E-7416-4037-AD5A-9180DF508C29}",
-                                                                "{51B0770C-8F9F-49E5-AAF1-0746CAB91E9C}",
-                                                                "{51E0048B-E159-4381-96AB-750C5E792156}",
-                                                                "{7503AEEE-0DD2-45E5-AC70-A863A99B28B7}",
-                                                                "{100FAC22-2565-4FC6-96F5-A9245CA36A16}",
-                                                                "{5A8FEA1E-E0B7-4AC4-B8E4-899F233DEF99}",
-                                                                "{7E8FE55B-D834-4A4C-A02D-A7614FD94363}",
-                                                                "{F9905F1E-6FCA-4EA2-A712-0D187DE744BD}"
+                                                                "{C19ACFC8-5926-464A-88D7-A02519E02895}",
+                                                                "{258C3F38-81D0-4C1B-A437-FAB2317D2499}",
+                                                                "{59C027A0-D543-4470-858D-FB94C6978CE8}",
+                                                                "{D7B9C337-5DEC-4A0F-B99D-9C134AC9443E}",
+                                                                "{3DC6628A-6AA8-4C1E-A089-686A6901AB75}",
+                                                                "{88F7B54B-C829-4634-AD23-B357A6E4CB71}",
+                                                                "{C40F23C5-A330-404C-94D0-14908C107467}",
+                                                                "{EA01D729-E2DD-4DE3-91B6-FBF368D1FA47}",
+                                                                "{23183B80-D78D-470A-8B20-88EB58CBB5B6}"
                                                             ]
                                                         },
                                                         "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                                             "$type": "GeometrySaveData",
                                                             "Position": [
                                                                 340.0,
-                                                                1580.0
+                                                                1180.0
                                                             ]
                                                         },
                                                         "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -9323,7 +9356,7 @@
                                                         },
                                                         "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                                             "$type": "PersistentIdComponentSaveData",
-                                                            "PersistentId": "{691B6CC5-94D1-4B03-B3F3-D40DCE98BC7E}"
+                                                            "PersistentId": "{B2E0C81F-CAD5-465C-A1EA-94DDD90FD6E6}"
                                                         }
                                                     }
                                                 }
@@ -9443,42 +9476,6 @@
                                                 }
                                             },
                                             {
-                                                "Type": 1,
-                                                "DataContainer": {
-                                                    "ComponentData": {
-                                                        "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                                            "$type": "NodeSaveData"
-                                                        },
-                                                        "{524D8380-AC09-444E-870E-9CEF2535B4A2}": {
-                                                            "$type": "CommentNodeTextSaveData",
-                                                            "Comment": "How to use VertMovement script canvas\n\nAdd this script canvas to the player as a script canvas component.\n\nEnsure ladders have static rigidbody box collider, then add tag \"Ladder\" to them\nEnjoy climbing up ladders\n\nEnsure trampolines have static rigidbody box collider, then add tag \"Tramp\" to them\nEnjoy jumping on trampolines\n\nEnsure any elevators have either the collision layer set to \"MovingPlatform\" or a child static rigidbody trigger collider with the TriggerParent script canvas attatched. Both solutions work.\nEnjoy riding moving platforms\n\n",
-                                                            "BackgroundColor": [
-                                                                0.9800000190734863,
-                                                                0.9700000286102295,
-                                                                0.6499999761581421
-                                                            ],
-                                                            "FontSettings": {
-                                                                "PixelSize": 16
-                                                            }
-                                                        },
-                                                        "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                                            "$type": "GeometrySaveData",
-                                                            "Position": [
-                                                                0.0,
-                                                                -300.0
-                                                            ]
-                                                        },
-                                                        "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                                            "$type": "StylingComponentSaveData"
-                                                        },
-                                                        "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                                            "$type": "PersistentIdComponentSaveData",
-                                                            "PersistentId": "{5E4D81D1-2B17-4D31-AAB7-F0D08BA5FCD2}"
-                                                        }
-                                                    }
-                                                }
-                                            },
-                                            {
                                                 "Type": 3,
                                                 "DataContainer": {
                                                     "ComponentData": {
@@ -9487,11 +9484,11 @@
                                                         },
                                                         "{524D8380-AC09-444E-870E-9CEF2535B4A2}": {
                                                             "$type": "CommentNodeTextSaveData",
-                                                            "Comment": "Trampoline Check",
+                                                            "Comment": "ElevatorPlatformCheck",
                                                             "BackgroundColor": [
-                                                                0.9800000190734863,
-                                                                0.9700000286102295,
-                                                                0.6499999761581421
+                                                                0.8843518495559692,
+                                                                0.658823549747467,
+                                                                0.4480659067630768
                                                             ],
                                                             "FontSettings": {
                                                                 "PixelSize": 16
@@ -9499,25 +9496,28 @@
                                                         },
                                                         "{6F4811ED-BD83-4A2A-8831-58EEA4020D57}": {
                                                             "$type": "NodeGroupFrameComponentSaveData",
-                                                            "DisplayHeight": 387.0,
-                                                            "DisplayWidth": 3440.0,
+                                                            "DisplayHeight": 580.0,
+                                                            "DisplayWidth": 3420.0,
                                                             "PersistentGroupedId": [
-                                                                "{C19ACFC8-5926-464A-88D7-A02519E02895}",
-                                                                "{258C3F38-81D0-4C1B-A437-FAB2317D2499}",
-                                                                "{59C027A0-D543-4470-858D-FB94C6978CE8}",
-                                                                "{D7B9C337-5DEC-4A0F-B99D-9C134AC9443E}",
-                                                                "{3DC6628A-6AA8-4C1E-A089-686A6901AB75}",
-                                                                "{88F7B54B-C829-4634-AD23-B357A6E4CB71}",
-                                                                "{C40F23C5-A330-404C-94D0-14908C107467}",
-                                                                "{EA01D729-E2DD-4DE3-91B6-FBF368D1FA47}",
-                                                                "{23183B80-D78D-470A-8B20-88EB58CBB5B6}"
+                                                                "{25673CF9-B568-4602-9A33-E406D275511E}",
+                                                                "{F96E318E-0993-46B7-995B-99D0981B4FB4}",
+                                                                "{F5235CFC-EE59-4042-8C3A-FFE8D34AC816}",
+                                                                "{09FE5056-1446-466E-9551-E9BBD7D19F31}",
+                                                                "{9C9FF66E-7416-4037-AD5A-9180DF508C29}",
+                                                                "{51B0770C-8F9F-49E5-AAF1-0746CAB91E9C}",
+                                                                "{51E0048B-E159-4381-96AB-750C5E792156}",
+                                                                "{7503AEEE-0DD2-45E5-AC70-A863A99B28B7}",
+                                                                "{100FAC22-2565-4FC6-96F5-A9245CA36A16}",
+                                                                "{5A8FEA1E-E0B7-4AC4-B8E4-899F233DEF99}",
+                                                                "{7E8FE55B-D834-4A4C-A02D-A7614FD94363}",
+                                                                "{F9905F1E-6FCA-4EA2-A712-0D187DE744BD}"
                                                             ]
                                                         },
                                                         "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                                             "$type": "GeometrySaveData",
                                                             "Position": [
                                                                 340.0,
-                                                                1180.0
+                                                                1580.0
                                                             ]
                                                         },
                                                         "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -9525,7 +9525,7 @@
                                                         },
                                                         "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                                             "$type": "PersistentIdComponentSaveData",
-                                                            "PersistentId": "{B2E0C81F-CAD5-465C-A1EA-94DDD90FD6E6}"
+                                                            "PersistentId": "{691B6CC5-94D1-4B03-B3F3-D40DCE98BC7E}"
                                                         }
                                                     }
                                                 }
@@ -9542,7 +9542,7 @@
                         },
                         {
                             "Key": {
-                                "id": 5848811431937
+                                "id": 162897736923282
                             },
                             "Value": {
                                 "ComponentData": {
@@ -9556,38 +9556,7 @@
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            2580.0,
-                                            500.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{02F27652-B7B5-41A3-9D32-0D3596AB977A}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 5853106399233
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            2580.0,
+                                            5540.0,
                                             280.0
                                         ]
                                     },
@@ -9597,14 +9566,14 @@
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{AF101DE0-CA84-4B88-80A1-808912651043}"
+                                        "PersistentId": "{307A567A-4D08-4C3D-B6CE-6BD838561E0A}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 5857401366529
+                                "id": 162902031890578
                             },
                             "Value": {
                                 "ComponentData": {
@@ -9618,98 +9587,7 @@
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            4340.0,
-                                            840.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{3E6AEA9E-9A7B-4D39-ABDE-2FD9C2811FB2}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 5861696333825
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MathNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            4580.0,
-                                            280.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{D08E53C6-ED12-4EC0-B3DC-D1F8CA4C9E54}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 5865991301121
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "LogicNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            2280.0,
-                                            840.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{0B983C0F-A95D-48EA-B8B7-361F92DCC71E}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 5870286268417
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            2060.0,
+                                            3480.0,
                                             1240.0
                                         ]
                                     },
@@ -9719,44 +9597,14 @@
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{3DC6628A-6AA8-4C1E-A089-686A6901AB75}"
+                                        "PersistentId": "{59C027A0-D543-4470-858D-FB94C6978CE8}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 5874581235713
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "LogicNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            1740.0,
-                                            1240.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{88F7B54B-C829-4634-AD23-B357A6E4CB71}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 5896056072193
+                                "id": 162906326857874
                             },
                             "Value": {
                                 "ComponentData": {
@@ -9770,8 +9618,8 @@
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            2880.0,
-                                            280.0
+                                            1280.0,
+                                            1240.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -9780,14 +9628,14 @@
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{C075E379-1EB6-494D-8D1B-564A4E0A3BEC}"
+                                        "PersistentId": "{EA01D729-E2DD-4DE3-91B6-FBF368D1FA47}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 5900351039489
+                                "id": 162910621825170
                             },
                             "Value": {
                                 "ComponentData": {
@@ -9818,7 +9666,7 @@
                         },
                         {
                             "Key": {
-                                "id": 5908940974081
+                                "id": 162914916792466
                             },
                             "Value": {
                                 "ComponentData": {
@@ -9832,8 +9680,8 @@
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            3160.0,
-                                            1240.0
+                                            3380.0,
+                                            840.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -9841,14 +9689,45 @@
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{C19ACFC8-5926-464A-88D7-A02519E02895}"
+                                        "PersistentId": "{524503DA-402E-43C8-AAC0-42FB44C406BF}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 5913235941377
+                                "id": 162919211759762
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "SetVariableNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            3700.0,
+                                            840.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".setVariable"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{432BB0B0-0CAC-4557-BD1C-EBB68DD7B372}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 162923506727058
                             },
                             "Value": {
                                 "ComponentData": {
@@ -9879,7 +9758,7 @@
                         },
                         {
                             "Key": {
-                                "id": 5917530908673
+                                "id": 162927801694354
                             },
                             "Value": {
                                 "ComponentData": {
@@ -9888,29 +9767,28 @@
                                     },
                                     "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                         "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                        "PaletteOverride": "MathNodeTitlePalette"
                                     },
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            560.0,
-                                            20.0
+                                            4580.0,
+                                            280.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
+                                        "$type": "StylingComponentSaveData"
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{70105A0E-98AA-446E-8990-A8C7B1943714}"
+                                        "PersistentId": "{D08E53C6-ED12-4EC0-B3DC-D1F8CA4C9E54}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 5921825875969
+                                "id": 162932096661650
                             },
                             "Value": {
                                 "ComponentData": {
@@ -9940,7 +9818,7 @@
                         },
                         {
                             "Key": {
-                                "id": 5926120843265
+                                "id": 162936391628946
                             },
                             "Value": {
                                 "ComponentData": {
@@ -9971,7 +9849,7 @@
                         },
                         {
                             "Key": {
-                                "id": 5930415810561
+                                "id": 162940686596242
                             },
                             "Value": {
                                 "ComponentData": {
@@ -9985,7 +9863,68 @@
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            4900.0,
+                                            2060.0,
+                                            1240.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{3DC6628A-6AA8-4C1E-A089-686A6901AB75}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 162944981563538
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "LogicNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            960.0,
+                                            1660.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{7E8FE55B-D834-4A4C-A02D-A7614FD94363}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 162949276530834
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            2880.0,
                                             280.0
                                         ]
                                     },
@@ -9995,14 +9934,14 @@
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{EEB225E3-3BAC-4DDE-9F35-AB2166B7F2A5}"
+                                        "PersistentId": "{C075E379-1EB6-494D-8D1B-564A4E0A3BEC}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 5934710777857
+                                "id": 162953571498130
                             },
                             "Value": {
                                 "ComponentData": {
@@ -10011,13 +9950,13 @@
                                     },
                                     "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                         "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "DefaultNodeTitlePalette"
+                                        "PaletteOverride": "MathNodeTitlePalette"
                                     },
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            1780.0,
-                                            800.0
+                                            3160.0,
+                                            1240.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -10025,14 +9964,14 @@
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{145B8927-890A-4248-B25B-C4F31B72B4DF}"
+                                        "PersistentId": "{C19ACFC8-5926-464A-88D7-A02519E02895}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 5939005745153
+                                "id": 162957866465426
                             },
                             "Value": {
                                 "ComponentData": {
@@ -10063,7 +10002,38 @@
                         },
                         {
                             "Key": {
-                                "id": 5943300712449
+                                "id": 162962161432722
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            3960.0,
+                                            280.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{75F133F5-221F-4A7C-A1AA-BFE49D523FE3}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 162966456400018
                             },
                             "Value": {
                                 "ComponentData": {
@@ -10077,8 +10047,8 @@
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            1020.0,
-                                            20.0
+                                            2180.0,
+                                            460.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -10087,14 +10057,74 @@
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{DF85554E-8E7B-4F5D-8A74-DAEB00D3253E}"
+                                        "PersistentId": "{A4D765F6-BC2C-4DB0-9039-2A4B4A1273EE}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 5947595679745
+                                "id": 162970751367314
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MathNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            1700.0,
+                                            1660.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{100FAC22-2565-4FC6-96F5-A9245CA36A16}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 162975046334610
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MathNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            2820.0,
+                                            1240.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{23183B80-D78D-470A-8B20-88EB58CBB5B6}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 162979341301906
                             },
                             "Value": {
                                 "ComponentData": {
@@ -10128,130 +10158,7 @@
                         },
                         {
                             "Key": {
-                                "id": 5951890647041
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            3500.0,
-                                            280.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{F3F347C5-BEF6-47E0-900C-14C545E2484D}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 5956185614337
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            4260.0,
-                                            280.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{1D58AB54-A40C-47B6-8C7B-67AE3A9844C0}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 5960480581633
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            1280.0,
-                                            1240.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{EA01D729-E2DD-4DE3-91B6-FBF368D1FA47}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 5964775548929
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "TimeNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            360.0,
-                                            20.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{6E1B7D15-9C60-4655-9D01-96BAF0C8645A}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 5969070516225
+                                "id": 162983636269202
                             },
                             "Value": {
                                 "ComponentData": {
@@ -10265,8 +10172,8 @@
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            3380.0,
-                                            840.0
+                                            5220.0,
+                                            280.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -10274,14 +10181,14 @@
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{524503DA-402E-43C8-AAC0-42FB44C406BF}"
+                                        "PersistentId": "{1632B15B-79D9-457E-9FF0-B59DCACE6A6D}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 5973365483521
+                                "id": 162987931236498
                             },
                             "Value": {
                                 "ComponentData": {
@@ -10295,8 +10202,8 @@
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            3700.0,
-                                            840.0
+                                            1020.0,
+                                            20.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -10305,168 +10212,14 @@
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{432BB0B0-0CAC-4557-BD1C-EBB68DD7B372}"
+                                        "PersistentId": "{DF85554E-8E7B-4F5D-8A74-DAEB00D3253E}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 5981955418113
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "LogicNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            980.0,
-                                            340.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{622275E2-D57A-43C6-A6CC-4C1EEC8D0985}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 5986250385409
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            360.0,
-                                            1240.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{D7B9C337-5DEC-4A0F-B99D-9C134AC9443E}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 5990545352705
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            2520.0,
-                                            1240.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{C40F23C5-A330-404C-94D0-14908C107467}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 5994840320001
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            360.0,
-                                            340.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{D91FF3CA-F449-417E-93E4-F5FEEBACDAA1}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 5999135287297
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            3960.0,
-                                            280.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{75F133F5-221F-4A7C-A1AA-BFE49D523FE3}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 6003430254593
+                                "id": 162992226203794
                             },
                             "Value": {
                                 "ComponentData": {
@@ -10497,343 +10250,7 @@
                         },
                         {
                             "Key": {
-                                "id": 6007725221889
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "SetVariableNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            2180.0,
-                                            460.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".setVariable"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{A4D765F6-BC2C-4DB0-9039-2A4B4A1273EE}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 6016315156481
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "SetVariableNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            2180.0,
-                                            300.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".setVariable"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{79D5EF86-FF80-42E2-AC28-33E941055922}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 6020610123777
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            5540.0,
-                                            280.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{307A567A-4D08-4C3D-B6CE-6BD838561E0A}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 6024905091073
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            3480.0,
-                                            1240.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{59C027A0-D543-4470-858D-FB94C6978CE8}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 6037789992961
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MathNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            2820.0,
-                                            1240.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{23183B80-D78D-470A-8B20-88EB58CBB5B6}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 6042084960257
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MathNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            5220.0,
-                                            280.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{1632B15B-79D9-457E-9FF0-B59DCACE6A6D}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 6046379927553
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "LogicNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            1780.0,
-                                            340.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{27E119E5-81D6-42E5-8B71-3ADB19DDAD97}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 144872607836161
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            2580.0,
-                                            1900.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{F9905F1E-6FCA-4EA2-A712-0D187DE744BD}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 144876902803457
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MathNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            1700.0,
-                                            1660.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{100FAC22-2565-4FC6-96F5-A9245CA36A16}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 144881197770753
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            3460.0,
-                                            1660.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{09FE5056-1446-466E-9551-E9BBD7D19F31}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 144885492738049
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MathNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            2580.0,
-                                            1660.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{9C9FF66E-7416-4037-AD5A-9180DF508C29}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 144889787705345
+                                "id": 162996521171090
                             },
                             "Value": {
                                 "ComponentData": {
@@ -10864,7 +10281,7 @@
                         },
                         {
                             "Key": {
-                                "id": 144894082672641
+                                "id": 163000816138386
                             },
                             "Value": {
                                 "ComponentData": {
@@ -10878,7 +10295,7 @@
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            1700.0,
+                                            2580.0,
                                             1900.0
                                         ]
                                     },
@@ -10888,14 +10305,45 @@
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{7503AEEE-0DD2-45E5-AC70-A863A99B28B7}"
+                                        "PersistentId": "{F9905F1E-6FCA-4EA2-A712-0D187DE744BD}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 144898377639937
+                                "id": 163005111105682
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            360.0,
+                                            1240.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{D7B9C337-5DEC-4A0F-B99D-9C134AC9443E}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 163009406072978
                             },
                             "Value": {
                                 "ComponentData": {
@@ -10909,7 +10357,7 @@
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            1260.0,
+                                            2140.0,
                                             1900.0
                                         ]
                                     },
@@ -10918,44 +10366,14 @@
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{F96E318E-0993-46B7-995B-99D0981B4FB4}"
+                                        "PersistentId": "{51B0770C-8F9F-49E5-AAF1-0746CAB91E9C}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 144902672607233
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "LogicNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            960.0,
-                                            1660.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{7E8FE55B-D834-4A4C-A02D-A7614FD94363}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 144906967574529
+                                "id": 163013701040274
                             },
                             "Value": {
                                 "ComponentData": {
@@ -10969,8 +10387,8 @@
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            2140.0,
-                                            1660.0
+                                            2580.0,
+                                            280.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -10979,14 +10397,14 @@
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{F5235CFC-EE59-4042-8C3A-FFE8D34AC816}"
+                                        "PersistentId": "{AF101DE0-CA84-4B88-80A1-808912651043}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 144911262541825
+                                "id": 163017996007570
                             },
                             "Value": {
                                 "ComponentData": {
@@ -11017,7 +10435,68 @@
                         },
                         {
                             "Key": {
-                                "id": 144915557509121
+                                "id": 163022290974866
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "LogicNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            1740.0,
+                                            1240.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{88F7B54B-C829-4634-AD23-B357A6E4CB71}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 163026585942162
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "SetVariableNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            2180.0,
+                                            300.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".setVariable"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{79D5EF86-FF80-42E2-AC28-33E941055922}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 163030880909458
                             },
                             "Value": {
                                 "ComponentData": {
@@ -11031,7 +10510,7 @@
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            2140.0,
+                                            1260.0,
                                             1900.0
                                         ]
                                     },
@@ -11040,14 +10519,135 @@
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{51B0770C-8F9F-49E5-AAF1-0746CAB91E9C}"
+                                        "PersistentId": "{F96E318E-0993-46B7-995B-99D0981B4FB4}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 144919852476417
+                                "id": 163035175876754
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            4340.0,
+                                            840.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{3E6AEA9E-9A7B-4D39-ABDE-2FD9C2811FB2}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 163039470844050
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MathNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            2580.0,
+                                            1660.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{9C9FF66E-7416-4037-AD5A-9180DF508C29}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 163043765811346
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "LogicNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            980.0,
+                                            340.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{622275E2-D57A-43C6-A6CC-4C1EEC8D0985}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 163048060778642
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "TimeNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            360.0,
+                                            20.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{6E1B7D15-9C60-4655-9D01-96BAF0C8645A}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 163052355745938
                             },
                             "Value": {
                                 "ComponentData": {
@@ -11072,6 +10672,406 @@
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
                                         "PersistentId": "{25673CF9-B568-4602-9A33-E406D275511E}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 163056650713234
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            3500.0,
+                                            280.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{F3F347C5-BEF6-47E0-900C-14C545E2484D}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 163060945680530
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "LogicNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            1780.0,
+                                            340.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{27E119E5-81D6-42E5-8B71-3ADB19DDAD97}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 163065240647826
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            2520.0,
+                                            1240.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{C40F23C5-A330-404C-94D0-14908C107467}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 163069535615122
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            1700.0,
+                                            1900.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{7503AEEE-0DD2-45E5-AC70-A863A99B28B7}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 163073830582418
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            360.0,
+                                            340.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{D91FF3CA-F449-417E-93E4-F5FEEBACDAA1}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 163078125549714
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            2580.0,
+                                            500.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{02F27652-B7B5-41A3-9D32-0D3596AB977A}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 163082420517010
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            4900.0,
+                                            280.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{EEB225E3-3BAC-4DDE-9F35-AB2166B7F2A5}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 163086715484306
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "LogicNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            2280.0,
+                                            840.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{0B983C0F-A95D-48EA-B8B7-361F92DCC71E}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 163091010451602
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            4260.0,
+                                            280.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{1D58AB54-A40C-47B6-8C7B-67AE3A9844C0}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 163095305418898
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            560.0,
+                                            20.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{70105A0E-98AA-446E-8990-A8C7B1943714}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 163099600386194
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "DefaultNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            1780.0,
+                                            800.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{145B8927-890A-4248-B25B-C4F31B72B4DF}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 163103895353490
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            2140.0,
+                                            1660.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{F5235CFC-EE59-4042-8C3A-FFE8D34AC816}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 163108190320786
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            3460.0,
+                                            1660.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{09FE5056-1446-466E-9551-E9BBD7D19F31}"
                                     }
                                 }
                             }
@@ -11287,12 +11287,12 @@
                                         },
                                         "isNullPointer": false,
                                         "$type": "{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9} AZStd::string",
-                                        "value": "moving_platform"
+                                        "value": "Moving Platform"
                                     },
                                     "VariableId": {
                                         "m_id": "{8E9F0358-D072-4949-A67C-92B3F777A91E}"
                                     },
-                                    "VariableName": "moving_platform"
+                                    "VariableName": "Moving Platform"
                                 }
                             },
                             {

--- a/Projects/FirstPersonProject/Levels/StarterScene/StarterScene.prefab
+++ b/Projects/FirstPersonProject/Levels/StarterScene/StarterScene.prefab
@@ -1773,6 +1773,7 @@
                             "Index": 1
                         },
                         "Trigger": true,
+                        "InSceneQueries": false,
                         "Position": [
                             0.0,
                             0.0,
@@ -4361,6 +4362,7 @@
                     "Id": 3649408574303999458,
                     "ColliderConfiguration": {
                         "Trigger": true,
+                        "InSceneQueries": false,
                         "MaterialSlots": {
                             "Slots": [
                                 {
@@ -15061,7 +15063,7 @@
                             -0.02458634227514267
                         ],
                         "Rotate": [
-                            90.00000762939453,
+                            90.0,
                             0.0,
                             0.0
                         ],

--- a/Projects/FirstPersonProject/Registry/physxsystemconfiguration.setreg
+++ b/Projects/FirstPersonProject/Registry/physxsystemconfiguration.setreg
@@ -7,7 +7,7 @@
                         "Layers": {
                             "LayerNames": [
                                 "Default",
-                                "moving_platform",
+                                "Platform",
                                 {},
                                 {},
                                 {},
@@ -87,6 +87,15 @@
                                         "Mask": 0
                                     },
                                     "ReadOnly": true
+                                },
+                                {
+                                    "Id": {
+                                        "GroupId": "{05D3561A-FBC6-48DF-A5BB-B872AD14EB30}"
+                                    },
+                                    "Name": "Moving Platform",
+                                    "Group": {
+                                        "Mask": 18446744073709551614
+                                    }
                                 }
                             ]
                         }

--- a/Projects/FirstPersonProject/project.json
+++ b/Projects/FirstPersonProject/project.json
@@ -13,7 +13,7 @@
         "FirstPersonProject"
     ],
     "icon_path": "preview.png",
-    "engine": "o3de-sdk",
+    "engine": "o3de",
     "external_subdirectories": [
         "Gem"
     ],


### PR DESCRIPTION
Rename the PhysX collision layer from 'moving_platform' to "Platform" and disable In Scene Queries for the trigger boxes / zones so the grounded check does not mistake them for a valid ground surface.

Use the new "Moving Platform" PhysX collision group name in the VertMovement script.

The spammed warnings in the console should no longer be there.